### PR TITLE
Fixes issue #14

### DIFF
--- a/content/danmaku.css
+++ b/content/danmaku.css
@@ -6,7 +6,7 @@
     height: 100%;
     pointer-events: none;
     overflow: hidden;
-    z-index: 10; /* YouTube的视频控制栏是60 */
+    z-index: 10;
 }
 
 .bilibili-danmaku-stage > div {

--- a/content/danmaku.css
+++ b/content/danmaku.css
@@ -6,7 +6,7 @@
     height: 100%;
     pointer-events: none;
     overflow: hidden;
-    z-index: 59; /* YouTube的视频控制栏是60 */
+    z-index: 10; /* YouTube的视频控制栏是60 */
 }
 
 .bilibili-danmaku-stage > div {

--- a/content/youtube.js
+++ b/content/youtube.js
@@ -301,28 +301,22 @@ async function getEnhancedVideoTitle(videoId) {
 
 // 查找视频容器
 function findVideoContainer() {
-    // 优先查找YouTube播放器容器
-    const ytdContainer = document.querySelector('#container.style-scope.ytd-player');
-    if (ytdContainer && ytdContainer.offsetHeight > 0) {
-        return ytdContainer;
-    }
-
-    // 备选1：查找视频容器
+    // 最佳目标：直接包裹 <video> 元素的容器
     const videoContainer = document.querySelector('.html5-video-container');
     if (videoContainer && videoContainer.offsetHeight > 0) {
         return videoContainer;
     }
 
-    // 备选2：查找整个播放器
-    const moviePlayer = document.querySelector('#movie_player');
-    if (moviePlayer && moviePlayer.offsetHeight > 0) {
-        return moviePlayer;
-    }
-
-    // 最后尝试：直接查找视频元素的父容器
+    // 备选方案：<video> 元素的直接父元素
     const video = document.querySelector('video');
     if (video && video.parentElement && video.parentElement.offsetHeight > 0) {
         return video.parentElement;
+    }
+
+    // 最后的备选：旧版播放器ID，兼容性考虑
+    const moviePlayer = document.querySelector('#movie_player');
+    if (moviePlayer && moviePlayer.offsetHeight > 0) {
+        return moviePlayer;
     }
 
     return null;


### PR DESCRIPTION
## 修复弹幕遮挡 YouTube 控制栏的问题 (#14)

### 问题描述
当前版本的弹幕会显示在 **YouTube 播放器控制栏**（如播放/暂停按钮、进度条）的上方，遮挡了原生 UI，影响用户操作。  

经过排查，问题根源有两点：

1. **错误的 DOM 注入点**  
   `content/youtube.js` 中的 `findVideoContainer` 函数会优先选择 `#container.style-scope.ytd-player` 作为弹幕的容器。  
   该节点是 YouTube 播放器最外层的容器，且自身的 `z-index` 非常高。  
   这导致无论如何调整弹幕的 `z-index`，都会被父容器强制提升到所有 UI 之上。

2. **不稳定的 CSS `z-index` 值**  
   原版本在 `content/danmaku.css` 中设置了 `z-index: 59;`，并注释其意图是低于 YouTube 控制栏的 60。  
   但 YouTube 的 UI `z-index` 是动态且不固定的，目前远高于 60，导致该值失效。

---

### 修复方案

1. **修正注入点 (`content/youtube.js`)**  
   - 修改 `findVideoContainer` 逻辑，使其优先选择 `.html5-video-container` 作为弹幕容器。  
   - `.html5-video-container` 仅直接包裹 `<video>` 元素，不包含控制栏，是理想的注入目标。  
   - 这样确保了弹幕的 `z-index` 能与 YouTube 原生 UI 在正确的上下文中进行比较。

2. **调整 Z-Index (`content/danmaku.css`)**  
   - 将 `.bilibili-danmaku-stage` 的 `z-index` 从 `59` 下调至 **`10`**。  
   - 该值能确保弹幕显示在视频之上，同时远低于 YouTube UI 组件的层级，避免未来兼容性问题。

---

### 最终效果
<img width="340" height="363" alt="image" src="https://github.com/user-attachments/assets/698963b7-7560-4564-b2e6-f6b3c7777a1b" />

弹幕正确显示在 **视频之上**、**YouTube 控制栏之下**。
