### PR TITLE
fix: 页面变化时 持续监控 channel信息更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: 安装依赖
-              if: steps.check_release.outputs.exists == 'false'  
+              if: steps.check_release.outputs.exists == 'false'
               run: npm ci
 
             - name: 创建多浏览器扩展包
@@ -56,7 +56,7 @@ jobs:
                   # 构建 Chrome 版本
                   echo "🔨 构建 Chrome 扩展..."
                   npm run build:chrome
-                  
+
                   # 打包 Chrome 版本
                   cd .output/chrome-mv3
                   zip -r "../../$CHROME_PACKAGE" .
@@ -65,7 +65,7 @@ jobs:
                   # 构建 Firefox 版本  
                   echo "🔨 构建 Firefox 扩展..."
                   npm run build:firefox
-                  
+
                   # 打包 Firefox 版本
                   cd .output/firefox-mv2
                   zip -r "../../$FIREFOX_PACKAGE" .
@@ -74,7 +74,7 @@ jobs:
                   # 构建 Edge 版本
                   echo "🔨 构建 Edge 扩展..."
                   npm run build:edge
-                  
+
                   # 打包 Edge 版本
                   cd .output/edge-mv3
                   zip -r "../../$EDGE_PACKAGE" .
@@ -83,7 +83,7 @@ jobs:
                   # 构建 Safari 版本
                   echo "🔨 构建 Safari 扩展..."
                   npm run build:safari
-                  
+
                   # 打包 Safari 版本
                   cd .output/safari-mv2
                   zip -r "../../$SAFARI_PACKAGE" .
@@ -94,7 +94,7 @@ jobs:
                   echo "📦 Firefox: $FIREFOX_PACKAGE"
                   echo "📦 Edge: $EDGE_PACKAGE"
                   echo "📦 Safari: $SAFARI_PACKAGE"
-                  
+
                   echo "chrome_package=$CHROME_PACKAGE" >> $GITHUB_ENV
                   echo "firefox_package=$FIREFOX_PACKAGE" >> $GITHUB_ENV
                   echo "edge_package=$EDGE_PACKAGE" >> $GITHUB_ENV

--- a/entrypoints/background/index.js
+++ b/entrypoints/background/index.js
@@ -387,13 +387,13 @@ export default defineBackground(() => {
     // 判断文本是否为纯英文和数字（去除标点符号后判断）
     function isPureEnglishOrNumber(text) {
         if (!text || typeof text !== 'string') return false;
-        
+
         // 先去除所有标点符号和特殊字符，只保留字母、数字和空格
         const cleaned = text.replace(/[^\w\s]/g, '');
-        
+
         // 如果清理后为空，说明只有标点符号
         if (!cleaned.trim()) return false;
-        
+
         // 判断是否只包含英文字母、数字和空格
         return /^[a-zA-Z0-9\s]*$/.test(cleaned);
     }
@@ -404,8 +404,8 @@ export default defineBackground(() => {
         if (parts.length === 1) return parts[0];
 
         // 分为纯英文数字部分和非纯英文数字部分
-        const nonPureEnglishParts = parts.filter(part => !isPureEnglishOrNumber(part));
-        const pureEnglishParts = parts.filter(part => isPureEnglishOrNumber(part));
+        const nonPureEnglishParts = parts.filter((part) => !isPureEnglishOrNumber(part));
+        const pureEnglishParts = parts.filter((part) => isPureEnglishOrNumber(part));
 
         // 优先从非纯英文数字部分中选择最长的
         if (nonPureEnglishParts.length > 0) {
@@ -429,9 +429,10 @@ export default defineBackground(() => {
         if (!title || typeof title !== 'string') return title;
 
         // 同时使用竖线和空格作为分隔符进行分割
-        const parts = title.split(/[｜|\s]+/)
-            .map(part => part.trim())
-            .filter(part => part.length > 0);
+        const parts = title
+            .split(/[｜|\s]+/)
+            .map((part) => part.trim())
+            .filter((part) => part.length > 0);
 
         // 如果分割后只有一个部分或无法分割，返回原标题
         if (parts.length <= 1) {
@@ -439,7 +440,7 @@ export default defineBackground(() => {
         }
 
         console.log(`标题分割结果:`, parts);
-        
+
         // 选择最佳部分
         return selectBestPart(parts);
     }
@@ -447,11 +448,11 @@ export default defineBackground(() => {
     // 去掉结尾的英文字符（只有去掉后还有内容时才去掉）
     function removeTrailingEnglish(text) {
         if (!text || typeof text !== 'string') return text;
-        
+
         // 匹配结尾的英文字母、数字、空格和常见标点符号
         const trailingEnglishRegex = /[a-zA-Z0-9\s\.,!?\-_'"():;]+$/;
         const match = text.match(trailingEnglishRegex);
-        
+
         if (match) {
             const withoutTrailing = text.slice(0, match.index).trim();
             // 只有去掉后还有内容时才返回去掉结尾的版本
@@ -460,7 +461,7 @@ export default defineBackground(() => {
                 return withoutTrailing;
             }
         }
-        
+
         return text; // 原样返回
     }
 
@@ -524,8 +525,8 @@ export default defineBackground(() => {
         try {
             const response = await fetch(`https://bsbsb.top/api/skipSegments?videoID=${bvid}`, {
                 headers: {
-                    "origin": "chrome-extension://dmkbhbnbpfijhgpnfahfioedledohfja",
-                    "x-ext-version": "1.1.5"
+                    origin: 'chrome-extension://dmkbhbnbpfijhgpnfahfioedledohfja',
+                    'x-ext-version': '1.1.5'
                 }
             });
 
@@ -540,11 +541,11 @@ export default defineBackground(() => {
             }
 
             const skipSegments = await response.json();
-            
+
             // 筛选出赞助（sponsor）类型的片段
             const sponsorSegments = skipSegments
-                .filter(segment => segment.category === 'sponsor')
-                .map(segment => segment.segment)
+                .filter((segment) => segment.category === 'sponsor')
+                .map((segment) => segment.segment)
                 .sort((a, b) => a[0] - b[0]); // 按开始时间排序
 
             if (sponsorSegments.length === 0) {
@@ -553,17 +554,21 @@ export default defineBackground(() => {
 
             // 获取bilibili视频原始长度（取第一个片段的videoDuration）
             const bilibiliVideoDuration = skipSegments[0]?.videoDuration;
-            
+
             if (bilibiliVideoDuration && youtubeVideoDuration) {
                 const durationDiff = Math.abs(bilibiliVideoDuration - youtubeVideoDuration);
-                
+
                 if (durationDiff <= 5) {
                     // 长度相近，YouTube可能未去sponsor，跳过处理
-                    console.log(`YouTube视频长度(${youtubeVideoDuration}s)与bilibili原始长度(${bilibiliVideoDuration}s)相近，跳过sponsor处理`);
+                    console.log(
+                        `YouTube视频长度(${youtubeVideoDuration}s)与bilibili原始长度(${bilibiliVideoDuration}s)相近，跳过sponsor处理`
+                    );
                     return danmakus;
                 }
-                
-                console.log(`YouTube视频长度(${youtubeVideoDuration}s)与bilibili原始长度(${bilibiliVideoDuration}s)差异较大，正常处理sponsor片段`);
+
+                console.log(
+                    `YouTube视频长度(${youtubeVideoDuration}s)与bilibili原始长度(${bilibiliVideoDuration}s)差异较大，正常处理sponsor片段`
+                );
             }
 
             console.log(`发现 ${sponsorSegments.length} 个广告片段，开始处理弹幕`);
@@ -578,12 +583,12 @@ export default defineBackground(() => {
                 const adjustedEndTime = endTime - totalRemovedTime;
 
                 // 移除广告片段时间范围内的弹幕
-                const filteredDanmakus = processedDanmakus.filter(danmaku => 
-                    danmaku.time < adjustedStartTime || danmaku.time >= adjustedEndTime
+                const filteredDanmakus = processedDanmakus.filter(
+                    (danmaku) => danmaku.time < adjustedStartTime || danmaku.time >= adjustedEndTime
                 );
 
                 // 将广告片段之后的弹幕时间轴向前偏移
-                const adjustedDanmakus = filteredDanmakus.map(danmaku => {
+                const adjustedDanmakus = filteredDanmakus.map((danmaku) => {
                     if (danmaku.time >= adjustedEndTime) {
                         return {
                             ...danmaku,
@@ -597,8 +602,10 @@ export default defineBackground(() => {
                 totalRemovedTime += segmentDuration;
             }
 
-            console.log(`广告片段处理完成，移除了 ${danmakus.length - processedDanmakus.length} 条弹幕，总计移除时长: ${totalRemovedTime.toFixed(2)}秒`);
-            
+            console.log(
+                `广告片段处理完成，移除了 ${danmakus.length - processedDanmakus.length} 条弹幕，总计移除时长: ${totalRemovedTime.toFixed(2)}秒`
+            );
+
             return processedDanmakus;
         } catch (error) {
             console.error('处理广告片段时出错:', error);
@@ -670,7 +677,11 @@ export default defineBackground(() => {
             formattedDanmakus.sort((a, b) => a.time - b.time);
 
             // 移除广告片段弹幕
-            const processedDanmakus = await removeAdSegments(formattedDanmakus, bvid, youtubeVideoDuration);
+            const processedDanmakus = await removeAdSegments(
+                formattedDanmakus,
+                bvid,
+                youtubeVideoDuration
+            );
 
             // 统计weight分布（用于调试）
             // const weightStats = {};
@@ -1240,7 +1251,11 @@ export default defineBackground(() => {
             return true; // 保持消息通道开启
         } else if (request.type === 'searchBilibiliVideo') {
             // 新增：B站视频搜索
-            searchBilibiliVideo(request.bilibiliUID, request.videoTitle, request.youtubeVideoDuration)
+            searchBilibiliVideo(
+                request.bilibiliUID,
+                request.videoTitle,
+                request.youtubeVideoDuration
+            )
                 .then((result) => {
                     sendResponse(result);
                 })

--- a/entrypoints/content/index.js
+++ b/entrypoints/content/index.js
@@ -608,13 +608,13 @@ export default defineContentScript({
 
                 console.log('视频切换:', { from: oldVideoId, to: videoId });
 
-                // 立即清除旧的页面信息
+                // 立即清除旧的页面信息和缓存
                 currentPageInfo = null;
                 if (oldVideoId) {
                     pageInfoCache.delete(oldVideoId);
                 }
 
-                // 通知background script页面切换
+                // 通知background script页面切换，并请求清理对应标签页的缓存
                 browser.runtime
                     .sendMessage({
                         type: 'pageChanged',

--- a/entrypoints/content/index.js
+++ b/entrypoints/content/index.js
@@ -666,11 +666,12 @@ export default defineContentScript({
                 } catch (error) {
                     console.error('页面信息监控出错:', error);
                     // 发生错误时停止监控，避免持续错误
-                    if (error.message && (
-                        error.message.includes('Extension context invalidated') ||
-                        error.message.includes('Could not establish connection') ||
-                        error.message.includes('The message port closed')
-                    )) {
+                    if (
+                        error.message &&
+                        (error.message.includes('Extension context invalidated') ||
+                            error.message.includes('Could not establish connection') ||
+                            error.message.includes('The message port closed'))
+                    ) {
                         console.log('扩展上下文失效或连接断开，停止监控');
                         stopPageInfoMonitoring();
                     }

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -751,7 +751,8 @@ function displayChannelInfo(pageInfo) {
     document.getElementById('channel-name').textContent = isBangumiChannel
         ? '哔哩哔哩动画'
         : channel.channelName || '未知频道';
-    document.getElementById('channel-id').textContent = `ID: ${channel.channelId || '未知'}`;
+    document.getElementById('channel-id').textContent =
+        `ID: ${decodeURIComponent(channel.channelId || '未知')}`;
 
     channelInfoDiv.style.display = 'block';
 
@@ -1243,7 +1244,14 @@ async function downloadDanmakuFromBV(bvid, youtubeVideoId = null) {
             console.log('获取YouTube视频长度失败:', error);
         }
 
-        console.log('下载弹幕 - BVID:', bvid, 'YouTube视频ID:', youtubeVideoId, 'YouTube视频长度:', youtubeVideoDuration);
+        console.log(
+            '下载弹幕 - BVID:',
+            bvid,
+            'YouTube视频ID:',
+            youtubeVideoId,
+            'YouTube视频长度:',
+            youtubeVideoDuration
+        );
 
         showStatus('正在下载弹幕...', 'loading');
 

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -516,7 +516,12 @@ async function getPageInfo(useCache = true) {
                     if (backgroundResponse.data.videoId === currentVideoId) {
                         return backgroundResponse.data;
                     } else {
-                        console.warn('background缓存的视频ID与当前不匹配，fallback到直接获取');
+                        console.warn('background缓存的视频ID与当前不匹配，清除缓存并重新获取');
+                        // 如果视频ID不匹配，清除background缓存
+                        await browser.runtime.sendMessage({
+                            type: 'clearTabCache',
+                            tabId: tab.id
+                        });
                     }
                 }
             } catch (error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "B2Y - YouTube 同步显示 Bilibili 弹幕",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "自动将Bilibili的弹幕同步显示在YouTube视频上",
     "main": "background/background.js",
     "scripts": {

--- a/utils/danmaku-engine.js
+++ b/utils/danmaku-engine.js
@@ -176,9 +176,9 @@ class DanmakuEngine {
         this.video.addEventListener('seeking', () => {
             const currentTime = this.video.currentTime;
             let timeDiff = 0;
-            if(this.pauseTime > 0) {
+            if (this.pauseTime > 0) {
                 timeDiff = Math.abs(currentTime - this.pauseTime);
-            }else{
+            } else {
                 timeDiff = Math.abs(currentTime - this.lastVideoTime);
             }
             console.log('时间差', timeDiff);
@@ -213,7 +213,7 @@ class DanmakuEngine {
             // 重置标记
             this.isRealSeeking = false;
         });
-        
+
         // 监听播放速度变化
         this.video.addEventListener('ratechange', () => {
             this.handleSpeedChange(this.video.playbackRate);
@@ -274,20 +274,20 @@ class DanmakuEngine {
 
     // 更新所有动画的速度
     updateAnimationSpeeds() {
-        this.tracks.forEach(track => {
-            track.items.forEach(item => {
+        this.tracks.forEach((track) => {
+            track.items.forEach((item) => {
                 if (item.animation) {
                     // 计算新的duration
                     const newDuration = item.baseDuration / this.settings.speed;
-                    
+
                     // 获取当前进度
                     const currentTime = item.animation.currentTime || 0;
                     const oldDuration = item.animation.effect.getTiming().duration;
                     const progress = currentTime / oldDuration;
-                    
+
                     // 更新动画timing
                     item.animation.effect.updateTiming({ duration: newDuration });
-                    
+
                     // 保持相同的进度
                     item.animation.currentTime = progress * newDuration;
                 }
@@ -321,16 +321,16 @@ class DanmakuEngine {
         if (!this.settings.enabled) return;
 
         this.isStarted = true;
-        
+
         // 恢复所有弹幕动画
-        this.tracks.forEach(track => {
-            track.items.forEach(item => {
+        this.tracks.forEach((track) => {
+            track.items.forEach((item) => {
                 if (item.animation && item.animation.playState === 'paused') {
                     item.animation.play();
                 }
             });
         });
-        
+
         // 启动弹幕发射器
         this.startEmitting();
     }
@@ -343,13 +343,13 @@ class DanmakuEngine {
         if (this.cleanupInterval) {
             clearInterval(this.cleanupInterval);
         }
-        
+
         // 使用requestAnimationFrame获得最高帧率
         this.emittingFrameId = null;
         this.cleanupFrameId = null;
         this.lastEmitTime = 0;
         this.lastCleanupTime = 0;
-        
+
         const emitLoop = (currentTime) => {
             if (this.isStarted && this.video && !this.video.paused) {
                 // 控制发射频率到每0.5秒一次
@@ -357,19 +357,19 @@ class DanmakuEngine {
                     this.checkAndEmitDanmakus();
                     this.lastEmitTime = currentTime;
                 }
-                
+
                 // 控制清理频率到每0.5秒一次
                 if (currentTime - this.lastCleanupTime >= 500) {
                     this.cleanup();
                     this.lastCleanupTime = currentTime;
                 }
             }
-            
+
             if (this.isStarted) {
                 this.emittingFrameId = requestAnimationFrame(emitLoop);
             }
         };
-        
+
         this.emittingFrameId = requestAnimationFrame(emitLoop);
     }
 
@@ -409,7 +409,7 @@ class DanmakuEngine {
 
     pause() {
         this.isStarted = false;
-        
+
         // 停止发射器
         if (this.emittingInterval) {
             clearInterval(this.emittingInterval);
@@ -423,10 +423,10 @@ class DanmakuEngine {
             cancelAnimationFrame(this.emittingFrameId);
             this.emittingFrameId = null;
         }
-        
+
         // 暂停所有弹幕动画
-        this.tracks.forEach(track => {
-            track.items.forEach(item => {
+        this.tracks.forEach((track) => {
+            track.items.forEach((item) => {
                 if (item.animation && item.animation.playState === 'running') {
                     item.animation.pause();
                 }
@@ -436,8 +436,8 @@ class DanmakuEngine {
 
     clear() {
         // 取消所有动画并清理DOM
-        this.tracks.forEach(track => {
-            track.items.forEach(item => {
+        this.tracks.forEach((track) => {
+            track.items.forEach((item) => {
                 if (item.animation) {
                     item.animation.cancel();
                 }
@@ -447,7 +447,7 @@ class DanmakuEngine {
             });
             track.items = [];
         });
-        
+
         // 清空舞台
         this.stage.innerHTML = '';
     }
@@ -465,25 +465,25 @@ class DanmakuEngine {
     // 处理播放速度变化
     handleSpeedChange(newRate) {
         console.log(`播放速度变化: ${newRate}x`);
-        
+
         // Web Animations API实现：需要重新计算所有弹幕的时间进度
         // 保持弹幕视觉速度恒定，但同步到新的播放速度
-        this.tracks.forEach(track => {
-            track.items.forEach(item => {
+        this.tracks.forEach((track) => {
+            track.items.forEach((item) => {
                 if (item.animation && item.danmaku) {
                     // 重新计算弹幕应该的进度
                     const currentVideoTime = this.video.currentTime + this.settings.timeOffset;
                     const visualElapsed = (currentVideoTime - item.danmaku.time) / newRate;
                     const progressMs = Math.max(0, visualElapsed * 1000);
                     const duration = item.animation.effect.getTiming().duration;
-                    
+
                     if (progressMs <= duration) {
                         item.animation.currentTime = progressMs;
                     }
                 }
             });
         });
-        
+
         console.log('弹幕位置已根据新播放速度重新计算');
     }
 
@@ -555,31 +555,34 @@ class DanmakuEngine {
         // 获取弹幕宽度
         const danmakuWidth = elem.offsetWidth;
         const stageWidth = this.stage.offsetWidth;
-        
-        // 计算动画参数  
+
+        // 计算动画参数
         const baseDuration = 8000;
         const adjustedDuration = baseDuration / this.settings.speed;
         const currentPlaybackRate = this.video?.playbackRate || 1.0;
-        
+
         // 使用Web Animations API创建动画
-        const animation = elem.animate([
+        const animation = elem.animate(
+            [
+                {
+                    transform: `translateX(${stageWidth}px)`,
+                    offset: 0
+                },
+                {
+                    transform: `translateX(-${danmakuWidth}px)`,
+                    offset: 1
+                }
+            ],
             {
-                transform: `translateX(${stageWidth}px)`,
-                offset: 0
-            },
-            {
-                transform: `translateX(-${danmakuWidth}px)`,
-                offset: 1
+                duration: adjustedDuration,
+                easing: 'linear',
+                fill: 'forwards'
             }
-        ], {
-            duration: adjustedDuration,
-            easing: 'linear',
-            fill: 'forwards'
-        });
-        
+        );
+
         // 不设置playbackRate，让弹幕速度保持恒定
         // animation.playbackRate = currentPlaybackRate; // 移除
-        
+
         // 设置动画进度到已经过的时间
         // 弹幕视觉速度保持恒定，需要根据播放速度反算实际经过时间
         const visualElapsed = elapsed / currentPlaybackRate; // 视觉上的经过时间
@@ -612,7 +615,7 @@ class DanmakuEngine {
         elem.style.whiteSpace = 'nowrap';
         elem.style.pointerEvents = 'none';
         elem.style.zIndex = '9999';
-        
+
         // 强制硬件加速和高性能
         elem.style.willChange = 'transform';
         elem.style.transform = 'translate3d(0, 0, 0)';
@@ -629,28 +632,31 @@ class DanmakuEngine {
         // 获取弹幕宽度
         const danmakuWidth = elem.offsetWidth;
         const stageWidth = this.stage.offsetWidth;
-        
+
         // 计算动画参数
         const baseDuration = 8000; // 基础8秒
         const adjustedDuration = baseDuration / this.settings.speed;
         // 移除playbackRate的影响，让弹幕速度保持恒定
-        
+
         // 使用Web Animations API创建动画
-        const animation = elem.animate([
+        const animation = elem.animate(
+            [
+                {
+                    transform: `translateX(${stageWidth}px)`,
+                    offset: 0
+                },
+                {
+                    transform: `translateX(-${danmakuWidth}px)`,
+                    offset: 1
+                }
+            ],
             {
-                transform: `translateX(${stageWidth}px)`,
-                offset: 0
-            },
-            {
-                transform: `translateX(-${danmakuWidth}px)`,
-                offset: 1
+                duration: adjustedDuration,
+                easing: 'linear',
+                fill: 'forwards'
             }
-        ], {
-            duration: adjustedDuration,
-            easing: 'linear',
-            fill: 'forwards'
-        });
-        
+        );
+
         // 不设置playbackRate，让弹幕速度保持恒定
         // animation.playbackRate = currentPlaybackRate; // 移除
 
@@ -682,11 +688,11 @@ class DanmakuEngine {
 
                 // 计算考虑播放速度的视觉进度
                 const visualElapsed = this.calculateVisualElapsed(
-                    currentVideoTime, 
-                    item.danmaku.time, 
+                    currentVideoTime,
+                    item.danmaku.time,
                     playbackRate
                 );
-                
+
                 const duration = item.animation.effect.getTiming().duration / 1000; // 转换为秒
                 const progress = Math.min(visualElapsed / duration, 1);
 
@@ -727,7 +733,7 @@ class DanmakuEngine {
 
                 // 检查动画状态
                 const animationState = item.animation.playState;
-                
+
                 // 动画完成或被取消时移除
                 if (animationState === 'finished' || animationState === 'idle') {
                     if (item.elem) item.elem.remove();
@@ -758,7 +764,7 @@ class DanmakuEngine {
     destroy() {
         this.pause();
         this.clear();
-        
+
         // 清理所有定时器和动画帧
         if (this.emittingInterval) {
             clearInterval(this.emittingInterval);
@@ -772,7 +778,7 @@ class DanmakuEngine {
             cancelAnimationFrame(this.emittingFrameId);
             this.emittingFrameId = null;
         }
-        
+
         if (this.stage) {
             this.stage.remove();
         }


### PR DESCRIPTION
- 尝试修复这个问题 https://github.com/ahaduoduoduo/bilibili-youtube-danmaku/issues/5 
我猜测是因为页面异步加载，导致插件获取pageinfo 时 channel 信息还没更新， 没有想到太好的方法
直接在页面url 变化时启动一个监控线程 每2s 刷新一次， 连续刷3次
在firefox 上简单测试过， 修复有效

- format 了代码 && decodeURI 中文channel id

code by claude-code

