### PR TITLE
Fix YouTube danmaku initialization timing and popup data isolation

### DIFF
--- a/entrypoints/background/index.js
+++ b/entrypoints/background/index.js
@@ -9,6 +9,62 @@ import '../../lib/opencc.min.js';
 export default defineBackground(() => {
     // 页面状态管理
     let tabPageStates = new Map(); // 存储每个标签页的页面状态
+    let pendingSearchResultsByTab = new Map();
+    let pendingNoMatchResultsByTab = new Map();
+
+    function getPendingPopupStorageKey(type, tabId) {
+        return `${type}:${tabId}`;
+    }
+
+    async function getPendingPopupData(type, tabId) {
+        const memoryStore =
+            type === 'pendingSearchResults'
+                ? pendingSearchResultsByTab
+                : pendingNoMatchResultsByTab;
+
+        if (memoryStore.has(tabId)) {
+            return memoryStore.get(tabId);
+        }
+
+        const storageKey = getPendingPopupStorageKey(type, tabId);
+        const result = await browser.storage.local.get(storageKey);
+        return result[storageKey] || null;
+    }
+
+    async function clearPendingPopupData(type, tabId) {
+        const memoryStore =
+            type === 'pendingSearchResults'
+                ? pendingSearchResultsByTab
+                : pendingNoMatchResultsByTab;
+
+        memoryStore.delete(tabId);
+        await browser.storage.local.remove(getPendingPopupStorageKey(type, tabId));
+    }
+
+    async function clearAllPendingPopupData(tabId) {
+        pendingSearchResultsByTab.delete(tabId);
+        pendingNoMatchResultsByTab.delete(tabId);
+        await browser.storage.local.remove([
+            getPendingPopupStorageKey('pendingSearchResults', tabId),
+            getPendingPopupStorageKey('pendingNoMatchResults', tabId)
+        ]);
+    }
+
+    async function setPendingPopupData(type, tabId, data) {
+        if (type === 'pendingSearchResults') {
+            pendingSearchResultsByTab.set(tabId, data);
+            pendingNoMatchResultsByTab.delete(tabId);
+            await browser.storage.local.remove(getPendingPopupStorageKey('pendingNoMatchResults', tabId));
+        } else {
+            pendingNoMatchResultsByTab.set(tabId, data);
+            pendingSearchResultsByTab.delete(tabId);
+            await browser.storage.local.remove(getPendingPopupStorageKey('pendingSearchResults', tabId));
+        }
+
+        await browser.storage.local.set({
+            [getPendingPopupStorageKey(type, tabId)]: data
+        });
+    }
 
     // 页面状态管理函数
     function getTabPageState(tabId) {
@@ -49,6 +105,9 @@ export default defineBackground(() => {
     // 监听标签页关闭事件
     browser.tabs.onRemoved.addListener((tabId) => {
         clearTabPageState(tabId);
+        clearAllPendingPopupData(tabId).catch((error) => {
+            console.log(`清理标签页${tabId}待展示数据失败:`, error);
+        });
     });
 
     // WBI签名相关配置
@@ -1160,19 +1219,19 @@ export default defineBackground(() => {
         return results;
     }
 
-    // 存储待发送的搜索结果
-    let pendingSearchResults = null;
-
-    // 存储待发送的未匹配结果
-    let pendingNoMatchResults = null;
-
     // 处理多个搜索结果的弹窗显示
-    async function handleMultipleResults(request) {
+    async function handleMultipleResults(request, sender) {
         try {
+            const tabId = sender.tab?.id;
+            if (tabId == null) {
+                throw new Error('无法确定搜索结果所属的标签页');
+            }
+
             console.log('处理多个搜索结果弹窗:', request.results.length);
 
             // 暂存搜索结果，等待popup准备好接收
-            pendingSearchResults = {
+            const pendingSearchResults = {
+                tabId: tabId,
                 results: request.results,
                 youtubeVideoId: request.youtubeVideoId,
                 channelInfo: request.channelInfo,
@@ -1180,10 +1239,7 @@ export default defineBackground(() => {
                 timestamp: Date.now()
             };
 
-            // 同时存储到storage作为备用
-            await browser.storage.local.set({
-                pendingSearchResults: pendingSearchResults
-            });
+            await setPendingPopupData('pendingSearchResults', tabId, pendingSearchResults);
 
             // 打开popup窗口
             try {
@@ -1210,22 +1266,25 @@ export default defineBackground(() => {
     }
 
     // 处理未匹配结果的弹窗显示
-    async function handleNoMatchResults(request) {
+    async function handleNoMatchResults(request, sender) {
         try {
+            const tabId = sender.tab?.id;
+            if (tabId == null) {
+                throw new Error('无法确定未匹配结果所属的标签页');
+            }
+
             console.log('处理未匹配结果弹窗:', request.channelInfo);
 
             // 暂存未匹配结果，等待popup准备好接收
-            pendingNoMatchResults = {
+            const pendingNoMatchResults = {
+                tabId: tabId,
                 youtubeVideoId: request.youtubeVideoId,
                 channelInfo: request.channelInfo,
                 videoTitle: request.videoTitle,
                 timestamp: Date.now()
             };
 
-            // 同时存储到storage作为备用
-            await browser.storage.local.set({
-                pendingNoMatchResults: pendingNoMatchResults
-            });
+            await setPendingPopupData('pendingNoMatchResults', tabId, pendingNoMatchResults);
 
             // 打开popup窗口
             try {
@@ -1465,7 +1524,7 @@ export default defineBackground(() => {
             return true; // 保持消息通道开启
         } else if (request.type === 'showMultipleResults') {
             // 新增：处理多个搜索结果的弹窗显示
-            handleMultipleResults(request)
+            handleMultipleResults(request, sender)
                 .then((result) => {
                     sendResponse(result);
                 })
@@ -1479,7 +1538,7 @@ export default defineBackground(() => {
             return true; // 保持消息通道开启
         } else if (request.type === 'showNoMatchResults') {
             // 新增：处理未匹配结果的弹窗显示
-            handleNoMatchResults(request)
+            handleNoMatchResults(request, sender)
                 .then((result) => {
                     sendResponse(result);
                 })
@@ -1497,23 +1556,17 @@ export default defineBackground(() => {
 
             // 处理异步操作
             (async () => {
-                // 优先使用内存中的数据
-                let dataToSend = pendingSearchResults;
-                let noMatchDataToSend = pendingNoMatchResults;
-
-                // 如果内存中没有数据，尝试从storage获取
-                if (!dataToSend && !noMatchDataToSend) {
-                    try {
-                        const result = await browser.storage.local.get([
-                            'pendingSearchResults',
-                            'pendingNoMatchResults'
-                        ]);
-                        dataToSend = result.pendingSearchResults;
-                        noMatchDataToSend = result.pendingNoMatchResults;
-                    } catch (error) {
-                        console.log('获取storage搜索结果失败:', error);
-                    }
+                const popupTabId = request.tabId;
+                if (popupTabId == null) {
+                    sendResponse({ success: false, message: 'missing tab id' });
+                    return;
                 }
+
+                const dataToSend = await getPendingPopupData('pendingSearchResults', popupTabId);
+                const noMatchDataToSend = await getPendingPopupData(
+                    'pendingNoMatchResults',
+                    popupTabId
+                );
 
                 if (dataToSend && dataToSend.results) {
                     // 检查数据是否过期（5分钟内有效）
@@ -1527,13 +1580,15 @@ export default defineBackground(() => {
                             browser.runtime
                                 .sendMessage({
                                     type: 'displayMultipleResults',
+                                    tabId: popupTabId,
                                     data: dataToSend
                                 })
-                                .then(() => {
-                                    // 发送成功后清理storage中的数据
-                                    browser.storage.local.remove('pendingSearchResults');
-                                    pendingSearchResults = null;
-                                    console.log('已清理pendingSearchResults数据');
+                                .then(async () => {
+                                    await clearPendingPopupData(
+                                        'pendingSearchResults',
+                                        popupTabId
+                                    );
+                                    console.log(`已清理标签页${popupTabId}的pendingSearchResults数据`);
                                 })
                                 .catch((error) => {
                                     console.log('发送搜索结果消息失败:', error);
@@ -1543,8 +1598,7 @@ export default defineBackground(() => {
                         sendResponse({ success: true });
                     } else {
                         console.log('搜索结果已过期，清理数据');
-                        pendingSearchResults = null;
-                        browser.storage.local.remove('pendingSearchResults');
+                        await clearPendingPopupData('pendingSearchResults', popupTabId);
                         sendResponse({ success: false, message: 'results expired' });
                     }
                 } else if (noMatchDataToSend) {
@@ -1559,13 +1613,15 @@ export default defineBackground(() => {
                             browser.runtime
                                 .sendMessage({
                                     type: 'displayNoMatchResults',
+                                    tabId: popupTabId,
                                     data: noMatchDataToSend
                                 })
-                                .then(() => {
-                                    // 发送成功后清理storage中的数据
-                                    browser.storage.local.remove('pendingNoMatchResults');
-                                    pendingNoMatchResults = null;
-                                    console.log('已清理pendingNoMatchResults数据');
+                                .then(async () => {
+                                    await clearPendingPopupData(
+                                        'pendingNoMatchResults',
+                                        popupTabId
+                                    );
+                                    console.log(`已清理标签页${popupTabId}的pendingNoMatchResults数据`);
                                 })
                                 .catch((error) => {
                                     console.log('发送未匹配结果消息失败:', error);
@@ -1575,8 +1631,7 @@ export default defineBackground(() => {
                         sendResponse({ success: true });
                     } else {
                         console.log('未匹配结果已过期，清理数据');
-                        pendingNoMatchResults = null;
-                        browser.storage.local.remove('pendingNoMatchResults');
+                        await clearPendingPopupData('pendingNoMatchResults', popupTabId);
                         sendResponse({ success: false, message: 'no match results expired' });
                     }
                 } else {
@@ -1589,9 +1644,16 @@ export default defineBackground(() => {
         } else if (request.type === 'clearSearchResults') {
             // 清理搜索结果
             console.log('清理搜索结果数据');
-            pendingSearchResults = null;
-            pendingNoMatchResults = null;
-            browser.storage.local.remove(['pendingSearchResults', 'pendingNoMatchResults']);
+            const popupTabId = request.tabId ?? sender.tab?.id;
+
+            if (popupTabId == null) {
+                sendResponse({ success: false, error: 'missing tab id' });
+                return true;
+            }
+
+            clearAllPendingPopupData(popupTabId).catch((error) => {
+                console.log(`清理标签页${popupTabId}搜索结果数据失败:`, error);
+            });
             sendResponse({ success: true });
 
             return true;
@@ -1642,23 +1704,30 @@ export default defineBackground(() => {
             // popup请求从background获取页面信息
             (async () => {
                 try {
-                    // 获取当前活跃标签页
-                    const [activeTab] = await browser.tabs.query({
-                        active: true,
-                        currentWindow: true
-                    });
+                    let targetTabId = request.tabId;
+                    let targetTabUrl = request.tabUrl;
 
-                    if (!activeTab || !activeTab.id) {
+                    if (targetTabId == null) {
+                        const [activeTab] = await browser.tabs.query({
+                            active: true,
+                            currentWindow: true
+                        });
+
+                        targetTabId = activeTab?.id;
+                        targetTabUrl = activeTab?.url;
+                    }
+
+                    if (targetTabId == null) {
                         sendResponse({ success: false, error: '无法获取当前标签页' });
                         return;
                     }
 
                     // 检查是否有缓存的页面状态
-                    const cachedState = getTabPageState(activeTab.id);
+                    const cachedState = getTabPageState(targetTabId);
 
                     if (cachedState) {
                         // 验证缓存的URL是否与当前标签页匹配
-                        if (cachedState.url === activeTab.url) {
+                        if (!targetTabUrl || cachedState.url === targetTabUrl) {
                             console.log('使用background缓存的页面信息');
                             sendResponse({
                                 success: true,
@@ -1668,7 +1737,7 @@ export default defineBackground(() => {
                             return;
                         } else {
                             console.log('缓存的URL不匹配，清除过期状态');
-                            clearTabPageState(activeTab.id);
+                            clearTabPageState(targetTabId);
                         }
                     }
 
@@ -1676,7 +1745,7 @@ export default defineBackground(() => {
                     console.log('向content script请求最新页面信息');
 
                     browser.tabs.sendMessage(
-                        activeTab.id,
+                        targetTabId,
                         {
                             type: 'getPageInfo'
                         },
@@ -1692,7 +1761,7 @@ export default defineBackground(() => {
 
                             if (response && response.success) {
                                 // 缓存新获取的信息
-                                setTabPageState(activeTab.id, response.data);
+                                setTabPageState(targetTabId, response.data);
                                 sendResponse({
                                     success: true,
                                     data: response.data,

--- a/entrypoints/content/index.js
+++ b/entrypoints/content/index.js
@@ -444,7 +444,6 @@ export default defineContentScript({
             await loadSettings();
 
             if (!isInitTokenCurrent(token)) {
-                resetDanmakuEngineState();
                 return false;
             }
 
@@ -454,7 +453,6 @@ export default defineContentScript({
                 const hasExistingDanmaku = await loadDanmakuForVideo(videoId);
 
                 if (!isInitTokenCurrent(token)) {
-                    resetDanmakuEngineState();
                     return false;
                 }
 
@@ -470,7 +468,6 @@ export default defineContentScript({
             }
 
             if (!isInitTokenCurrent(token)) {
-                resetDanmakuEngineState();
                 return false;
             }
 

--- a/entrypoints/content/index.js
+++ b/entrypoints/content/index.js
@@ -11,6 +11,8 @@ export default defineContentScript({
         let currentVideoId = null;
         let currentPageInfo = null;
         let pageInfoCache = new Map();
+        let activeInitToken = 0;
+        let pendingInitTimeout = null;
 
         // 获取YouTube视频ID
         function getVideoId() {
@@ -349,8 +351,25 @@ export default defineContentScript({
             return null;
         }
 
-        async function waitForVideoContainer(maxAttempts = 20, delay = 500) {
+        function isInitTokenCurrent(token) {
+            return token === activeInitToken;
+        }
+
+        function resetDanmakuEngineState() {
+            if (danmakuEngine) {
+                danmakuEngine.destroy();
+                danmakuEngine = null;
+            }
+
+            stopAdStatusMonitoring();
+        }
+
+        async function waitForVideoContainer(token, maxAttempts = 20, delay = 500) {
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                if (!isInitTokenCurrent(token)) {
+                    return null;
+                }
+
                 const container = findVideoContainer();
                 if (container) {
                     return container;
@@ -375,9 +394,35 @@ export default defineContentScript({
             return null;
         }
 
+        function scheduleDanmakuEngineInit({ delay = 1000, updatePageInfo = false } = {}) {
+            activeInitToken += 1;
+            const token = activeInitToken;
+
+            if (pendingInitTimeout) {
+                clearTimeout(pendingInitTimeout);
+            }
+
+            pendingInitTimeout = setTimeout(async () => {
+                pendingInitTimeout = null;
+
+                const initialized = await initDanmakuEngine(token);
+                if (initialized && updatePageInfo && isInitTokenCurrent(token)) {
+                    await updateCurrentPageInfo();
+                }
+            }, delay);
+        }
+
         // 初始化弹幕引擎
-        async function initDanmakuEngine() {
-            const container = await waitForVideoContainer();
+        async function initDanmakuEngine(token = activeInitToken) {
+            if (!isInitTokenCurrent(token)) {
+                return false;
+            }
+
+            const container = await waitForVideoContainer(token);
+            if (!isInitTokenCurrent(token)) {
+                return false;
+            }
+
             if (!container) {
                 console.log('未找到视频容器');
                 return false;
@@ -390,13 +435,7 @@ export default defineContentScript({
                 height: container.offsetHeight
             });
 
-            // 销毁旧的引擎
-            if (danmakuEngine) {
-                danmakuEngine.destroy();
-            }
-
-            // 停止之前的监控
-            stopAdStatusMonitoring();
+            resetDanmakuEngineState();
 
             // 创建新引擎
             danmakuEngine = new DanmakuEngine(container);
@@ -404,18 +443,35 @@ export default defineContentScript({
             // 加载设置
             await loadSettings();
 
+            if (!isInitTokenCurrent(token)) {
+                resetDanmakuEngineState();
+                return false;
+            }
+
             // 尝试加载当前视频的弹幕
             const videoId = getVideoId();
             if (videoId) {
                 const hasExistingDanmaku = await loadDanmakuForVideo(videoId);
 
+                if (!isInitTokenCurrent(token)) {
+                    resetDanmakuEngineState();
+                    return false;
+                }
+
                 // 如果没有现有弹幕，触发自动检测
                 if (!hasExistingDanmaku) {
                     // 延迟执行自动检测，确保页面完全加载
                     setTimeout(() => {
-                        autoCheckAndDownloadDanmaku();
+                        if (isInitTokenCurrent(token)) {
+                            autoCheckAndDownloadDanmaku(token);
+                        }
                     }, 1000);
                 }
+            }
+
+            if (!isInitTokenCurrent(token)) {
+                resetDanmakuEngineState();
+                return false;
             }
 
             // 启动广告状态监控
@@ -462,8 +518,12 @@ export default defineContentScript({
         }
 
         // 自动检测并下载弹幕
-        async function autoCheckAndDownloadDanmaku() {
+        async function autoCheckAndDownloadDanmaku(token = activeInitToken) {
             try {
+                if (!isInitTokenCurrent(token)) {
+                    return;
+                }
+
                 const videoId = getVideoId();
                 if (!videoId) {
                     console.log('无法获取视频ID，跳过自动检测');
@@ -472,6 +532,10 @@ export default defineContentScript({
 
                 // 获取频道信息
                 const channelInfo = await getChannelInfo();
+                if (!isInitTokenCurrent(token)) {
+                    return;
+                }
+
                 if (!channelInfo.success || !channelInfo.channelId) {
                     console.log('无法获取频道信息，跳过自动检测');
                     return;
@@ -479,6 +543,10 @@ export default defineContentScript({
 
                 // 获取增强的视频标题（支持多语言原始标题）
                 const videoTitle = await getEnhancedVideoTitle(videoId);
+                if (!isInitTokenCurrent(token)) {
+                    return;
+                }
+
                 if (!videoTitle) {
                     console.log('无法获取视频标题，跳过自动检测');
                     return;
@@ -511,6 +579,10 @@ export default defineContentScript({
                                 episodeNumber: parseResult.episode,
                                 youtubeVideoId: videoId
                             });
+
+                            if (!isInitTokenCurrent(token)) {
+                                return;
+                            }
 
                             if (response.success) {
                                 console.log(`番剧弹幕自动下载成功: ${response.count} 条`);
@@ -546,6 +618,10 @@ export default defineContentScript({
                     channelInfo.channelId
                 );
 
+                if (!isInitTokenCurrent(token)) {
+                    return;
+                }
+
                 if (!association) {
                     console.log('频道未关联B站UP主，跳过自动检测');
                     return;
@@ -573,6 +649,10 @@ export default defineContentScript({
                     youtubeVideoDuration: youtubeVideoDuration
                 });
 
+                if (!isInitTokenCurrent(token)) {
+                    return;
+                }
+
                 if (searchResponse.success && searchResponse.results.length > 0) {
                     console.log(`找到 ${searchResponse.results.length} 个匹配视频`);
 
@@ -587,6 +667,10 @@ export default defineContentScript({
                             youtubeVideoId: videoId,
                             youtubeVideoDuration: youtubeVideoDuration
                         });
+
+                        if (!isInitTokenCurrent(token)) {
+                            return;
+                        }
 
                         if (downloadResponse.success) {
                             console.log(`自动下载弹幕成功: ${downloadResponse.count} 条`);
@@ -658,6 +742,8 @@ export default defineContentScript({
                     pageInfoCache.delete(oldVideoId);
                 }
 
+                resetDanmakuEngineState();
+
                 // 通知background script页面切换
                 browser.runtime
                     .sendMessage({
@@ -669,11 +755,7 @@ export default defineContentScript({
                     .catch((error) => console.log('通知页面切换失败:', error));
 
                 // 延迟初始化，等待页面加载
-                setTimeout(async () => {
-                    await initDanmakuEngine();
-                    // 初始化完成后更新页面信息
-                    await updateCurrentPageInfo();
-                }, 1000);
+                scheduleDanmakuEngineInit({ delay: 1000, updatePageInfo: true });
             }
         }
 
@@ -908,10 +990,10 @@ export default defineContentScript({
         // 页面加载完成后初始化
         if (document.readyState === 'loading') {
             document.addEventListener('DOMContentLoaded', () => {
-                setTimeout(initDanmakuEngine, 1000);
+                scheduleDanmakuEngineInit({ delay: 1000 });
             });
         } else {
-            setTimeout(initDanmakuEngine, 1000);
+            scheduleDanmakuEngineInit({ delay: 1000 });
         }
     }
 });

--- a/entrypoints/content/index.js
+++ b/entrypoints/content/index.js
@@ -13,11 +13,111 @@ export default defineContentScript({
         let pageInfoCache = new Map();
         let activeInitToken = 0;
         let pendingInitTimeout = null;
+        const channelNameSelectors = [
+            'yt-formatted-string.ytd-channel-name a',
+            '#channel-name .ytd-channel-name a',
+            '.ytd-video-owner-renderer .ytd-channel-name a',
+            'ytd-channel-name a',
+            '#owner-sub-count a',
+            '.ytd-channel-name a'
+        ];
+        const channelLinkFallbackSelectors = ['a[href*="/@"]', 'a[href*="/channel/"]'];
+        const channelAvatarSelectors = [
+            '#avatar img',
+            '.ytd-video-owner-renderer img',
+            'yt-img-shadow img[alt*="avatar"]',
+            'yt-img-shadow img[alt*="Avatar"]'
+        ];
+        const channelRootSelectors = ['ytd-watch-metadata', '#owner', 'ytd-video-owner-renderer'];
 
         // 获取YouTube视频ID
         function getVideoId() {
             const match = window.location.href.match(/[?&]v=([^&]+)/);
             return match ? match[1] : null;
+        }
+
+        function extractChannelIdFromHref(href) {
+            if (!href) {
+                return '';
+            }
+
+            let match = href.match(/@([^\/\?#]+)/);
+            if (match) {
+                return '@' + match[1];
+            }
+
+            match = href.match(/channel\/([^\/\?#]+)/);
+            return match ? match[1] : '';
+        }
+
+        function getVisibleElements(selectors, root = document) {
+            const elements = [];
+            const seen = new Set();
+
+            for (const selector of selectors) {
+                const matches = root.querySelectorAll(selector);
+                for (const element of matches) {
+                    if (seen.has(element) || !isVisibleElement(element)) {
+                        continue;
+                    }
+
+                    seen.add(element);
+                    elements.push(element);
+                }
+            }
+
+            return elements;
+        }
+
+        function findChannelLinkCandidate() {
+            const visibleRoots = getVisibleElements(channelRootSelectors);
+
+            for (const root of visibleRoots) {
+                const scopedLinks = getVisibleElements(channelNameSelectors, root);
+                const completeLink = scopedLinks.find((element) => {
+                    return element.textContent.trim() && extractChannelIdFromHref(element.href);
+                });
+
+                if (completeLink) {
+                    return completeLink;
+                }
+            }
+
+            const globalCandidates = [
+                ...getVisibleElements(channelNameSelectors),
+                ...getVisibleElements(channelLinkFallbackSelectors)
+            ];
+
+            return (
+                globalCandidates.find((element) => {
+                    return element.textContent.trim() && extractChannelIdFromHref(element.href);
+                }) || globalCandidates[0] || null
+            );
+        }
+
+        function getChannelAvatar(channelLink) {
+            const avatarSearchRoots = [];
+            const ownerRoot = channelLink?.closest('#owner, ytd-video-owner-renderer, ytd-watch-metadata');
+
+            if (ownerRoot) {
+                avatarSearchRoots.push(ownerRoot);
+            }
+
+            avatarSearchRoots.push(...getVisibleElements(channelRootSelectors));
+
+            for (const root of avatarSearchRoots) {
+                const avatar = getVisibleElements(channelAvatarSelectors, root).find(
+                    (element) => !!element.src
+                );
+                if (avatar) {
+                    return avatar.src;
+                }
+            }
+
+            const fallbackAvatar = getVisibleElements(channelAvatarSelectors).find(
+                (element) => !!element.src
+            );
+            return fallbackAvatar ? fallbackAvatar.src : '';
         }
 
         // 获取YouTube频道信息（增强版）
@@ -28,80 +128,11 @@ export default defineContentScript({
                 let channelId = '';
                 let channelAvatar = '';
 
-                // 统一从频道链接元素获取名称和ID
-                const nameSelectors = [
-                    'yt-formatted-string.ytd-channel-name a',
-                    '#channel-name .ytd-channel-name a',
-                    '.ytd-video-owner-renderer .ytd-channel-name a',
-                    'ytd-channel-name a',
-                    '#owner-sub-count a',
-                    '.ytd-channel-name a'
-                ];
-
-                for (const selector of nameSelectors) {
-                    const element = document.querySelector(selector);
-                    if (element && element.textContent.trim()) {
-                        channelName = element.textContent.trim();
-
-                        // 同时从该元素获取频道ID
-                        if (element.href) {
-                            // 优先匹配 @username 格式
-                            let match = element.href.match(/@([^\/\?#]+)/);
-                            if (match) {
-                                channelId = '@' + match[1];
-                            } else {
-                                // 备选：匹配 /channel/UC... 格式
-                                match = element.href.match(/channel\/([^\/\?#]+)/);
-                                if (match) {
-                                    channelId = match[1];
-                                }
-                            }
-                        }
-
-                        // 如果获取到了名称和ID，结束循环
-                        if (channelName && channelId) {
-                            break;
-                        }
-                    }
-                }
-
-                // 如果上面没有获取到ID，尝试查找其他包含频道链接的元素
-                if (!channelId) {
-                    const channelElements = document.querySelectorAll(
-                        'a[href*="/@"], a[href*="/channel/"]'
-                    );
-                    for (const element of channelElements) {
-                        if (element.href) {
-                            // 优先匹配 @username 格式
-                            let match = element.href.match(/@([^\/\?#]+)/);
-                            if (match) {
-                                channelId = '@' + match[1];
-                                break;
-                            } else {
-                                // 备选：匹配 /channel/UC... 格式
-                                match = element.href.match(/channel\/([^\/\?#]+)/);
-                                if (match) {
-                                    channelId = match[1];
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // 获取频道头像
-                const avatarSelectors = [
-                    '#avatar img',
-                    '.ytd-video-owner-renderer img',
-                    'yt-img-shadow img[alt*="avatar"], yt-img-shadow img[alt*="Avatar"]'
-                ];
-
-                for (const selector of avatarSelectors) {
-                    const element = document.querySelector(selector);
-                    if (element && element.src) {
-                        channelAvatar = element.src;
-                        break;
-                    }
+                const channelLink = findChannelLinkCandidate();
+                if (channelLink) {
+                    channelName = channelLink.textContent.trim();
+                    channelId = extractChannelIdFromHref(channelLink.href);
+                    channelAvatar = getChannelAvatar(channelLink);
                 }
 
                 // 如果信息不完整且重试次数小于2，则重试
@@ -187,7 +218,7 @@ export default defineContentScript({
         }
 
         // 更新当前页面信息
-        async function updateCurrentPageInfo() {
+        async function updateCurrentPageInfo({ forceRefresh = false } = {}) {
             try {
                 const videoId = getVideoId();
                 if (!videoId) {
@@ -196,7 +227,7 @@ export default defineContentScript({
                 }
 
                 // 检查缓存
-                if (pageInfoCache.has(videoId)) {
+                if (!forceRefresh && pageInfoCache.has(videoId)) {
                     const cached = pageInfoCache.get(videoId);
                     // 如果缓存时间在30秒内，直接使用
                     if (Date.now() - cached.timestamp < 30000) {
@@ -208,10 +239,40 @@ export default defineContentScript({
                 console.log('更新页面信息:', videoId);
 
                 // 获取频道信息（可能需要重试）
-                const channelInfo = await getChannelInfo();
+                const initialChannelInfo = await getChannelInfo();
 
                 // 获取视频标题
                 const videoTitle = await getEnhancedVideoTitle(videoId);
+
+                const currentVideoId = getVideoId();
+                if (currentVideoId !== videoId) {
+                    console.log('页面信息更新期间视频已切换，忽略过期结果:', {
+                        requestedVideoId: videoId,
+                        currentVideoId: currentVideoId
+                    });
+                    return null;
+                }
+
+                // YouTube SPA 切换时，频道 DOM 可能会比标题更晚稳定，发布前再校验一次。
+                const revalidatedChannelInfo = await getChannelInfo();
+                const channelInfo = revalidatedChannelInfo.success
+                    ? revalidatedChannelInfo
+                    : initialChannelInfo;
+
+                if (
+                    initialChannelInfo.success &&
+                    revalidatedChannelInfo.success &&
+                    (initialChannelInfo.channelId !== revalidatedChannelInfo.channelId ||
+                        initialChannelInfo.channelName !== revalidatedChannelInfo.channelName)
+                ) {
+                    console.log('页面信息更新期间频道信息发生变化，使用重新校验后的结果:', {
+                        videoId: videoId,
+                        initialChannelId: initialChannelInfo.channelId,
+                        initialChannelName: initialChannelInfo.channelName,
+                        revalidatedChannelId: revalidatedChannelInfo.channelId,
+                        revalidatedChannelName: revalidatedChannelInfo.channelName
+                    });
+                }
 
                 if (channelInfo.success && videoTitle) {
                     const pageInfo = {
@@ -318,6 +379,15 @@ export default defineContentScript({
                 return false;
             }
 
+            if (!element.isConnected || element.closest('[hidden], [aria-hidden="true"]')) {
+                return false;
+            }
+
+            const style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden') {
+                return false;
+            }
+
             const rect = element.getBoundingClientRect();
             return rect.width > 0 && rect.height > 0;
         }
@@ -408,6 +478,16 @@ export default defineContentScript({
                 const initialized = await initDanmakuEngine(token);
                 if (initialized && updatePageInfo && isInitTokenCurrent(token)) {
                     await updateCurrentPageInfo();
+
+                    setTimeout(() => {
+                        if (!isInitTokenCurrent(token)) {
+                            return;
+                        }
+
+                        updateCurrentPageInfo({ forceRefresh: true }).catch((error) => {
+                            console.log('延迟复查页面信息失败:', error);
+                        });
+                    }, 1500);
                 }
             }, delay);
         }
@@ -781,17 +861,25 @@ export default defineContentScript({
 
                         // 优先使用缓存的页面信息
                         if (currentPageInfo && currentPageInfo.videoId === videoId) {
-                            console.log('使用缓存的页面信息');
-                            sendResponse({
-                                success: true,
-                                data: currentPageInfo
+                            const cacheAge = Date.now() - currentPageInfo.timestamp;
+                            if (cacheAge > 1500) {
+                                console.log('使用缓存的页面信息');
+                                sendResponse({
+                                    success: true,
+                                    data: currentPageInfo
+                                });
+                                return;
+                            }
+
+                            console.log('页面信息刚更新，重新校验频道信息...', {
+                                videoId: videoId,
+                                cacheAge: cacheAge
                             });
-                            return;
                         }
 
                         // 重新获取页面信息
                         console.log('重新获取页面信息...');
-                        await updateCurrentPageInfo();
+                        await updateCurrentPageInfo({ forceRefresh: !!currentPageInfo });
 
                         if (currentPageInfo) {
                             sendResponse({

--- a/entrypoints/content/index.js
+++ b/entrypoints/content/index.js
@@ -311,23 +311,65 @@ export default defineContentScript({
         }
 
         // 查找视频容器
+        function isVisibleElement(element) {
+            if (!element) {
+                return false;
+            }
+
+            const rect = element.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+        }
+
         function findVideoContainer() {
             // 最佳目标：直接包裹 <video> 元素的容器
             const videoContainer = document.querySelector('.html5-video-container');
-            if (videoContainer && videoContainer.offsetHeight > 0) {
+            if (isVisibleElement(videoContainer)) {
                 return videoContainer;
             }
 
-            // 备选方案：<video> 元素的直接父元素
+            // 备选方案：优先使用 <video> 最近的播放器容器
             const video = document.querySelector('video');
-            if (video && video.parentElement && video.parentElement.offsetHeight > 0) {
-                return video.parentElement;
+            if (video) {
+                const closestContainer = video.closest('.html5-video-container');
+                if (isVisibleElement(closestContainer)) {
+                    return closestContainer;
+                }
+
+                if (isVisibleElement(video.parentElement)) {
+                    return video.parentElement;
+                }
             }
 
             // 最后的备选：旧版播放器ID，兼容性考虑
             const moviePlayer = document.querySelector('#movie_player');
-            if (moviePlayer && moviePlayer.offsetHeight > 0) {
+            if (isVisibleElement(moviePlayer)) {
                 return moviePlayer;
+            }
+
+            return null;
+        }
+
+        async function waitForVideoContainer(maxAttempts = 20, delay = 500) {
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                const container = findVideoContainer();
+                if (container) {
+                    return container;
+                }
+
+                if (attempt === 1 || attempt === maxAttempts || attempt % 5 === 0) {
+                    const video = document.querySelector('video');
+                    const rect = video ? video.getBoundingClientRect() : null;
+                    console.log('等待视频容器...', {
+                        attempt,
+                        hasVideo: !!video,
+                        videoReadyState: video ? video.readyState : null,
+                        videoSize: rect
+                            ? `${Math.round(rect.width)}x${Math.round(rect.height)}`
+                            : 'N/A'
+                    });
+                }
+
+                await new Promise((resolve) => setTimeout(resolve, delay));
             }
 
             return null;
@@ -335,10 +377,10 @@ export default defineContentScript({
 
         // 初始化弹幕引擎
         async function initDanmakuEngine() {
-            const container = findVideoContainer();
+            const container = await waitForVideoContainer();
             if (!container) {
                 console.log('未找到视频容器');
-                return;
+                return false;
             }
 
             console.log('找到视频容器:', {
@@ -378,6 +420,8 @@ export default defineContentScript({
 
             // 启动广告状态监控
             startAdStatusMonitoring();
+
+            return true;
         }
 
         // 加载设置
@@ -427,7 +471,7 @@ export default defineContentScript({
                 }
 
                 // 获取频道信息
-                const channelInfo = getChannelInfo();
+                const channelInfo = await getChannelInfo();
                 if (!channelInfo.success || !channelInfo.channelId) {
                     console.log('无法获取频道信息，跳过自动检测');
                     return;

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -7,6 +7,10 @@ async function getCurrentTab() {
     return tab;
 }
 
+function getPendingStorageKey(type, tabId) {
+    return `${type}:${tabId}`;
+}
+
 // 解析B站视频ID
 function parseBilibiliUrl(url) {
     const match = url.match(/bilibili\.com\/video\/(BV\w+)/);
@@ -363,7 +367,12 @@ async function checkCurrentPageDanmaku() {
         updateManualInputUI(true, data.bilibili_url);
 
         // 当检测到有弹幕数据时，清理可能残留的未匹配状态数据
-        await browser.storage.local.remove(['pendingNoMatchResults', 'pendingSearchResults']);
+        await browser.runtime
+            .sendMessage({
+                type: 'clearSearchResults',
+                tabId: tab.id
+            })
+            .catch((error) => console.log('清理待展示搜索结果失败:', error));
     } else {
         const noMatchData = await getNoMatchDataForCurrentPage();
         updateManualInputUI(false, '', noMatchData);
@@ -528,7 +537,9 @@ async function getPageInfo(useCache = true) {
         if (useCache) {
             try {
                 const backgroundResponse = await browser.runtime.sendMessage({
-                    type: 'getPageInfoFromBackground'
+                    type: 'getPageInfoFromBackground',
+                    tabId: tab.id,
+                    tabUrl: tab.url
                 });
 
                 if (backgroundResponse && backgroundResponse.success) {
@@ -1057,8 +1068,14 @@ function displaySearchResults(results, youtubeVideoId, noMatchData = null) {
 // 检查待显示的搜索结果（作为备用方案）
 async function checkPendingSearchResults() {
     try {
-        const result = await browser.storage.local.get('pendingSearchResults');
-        const pendingResults = result.pendingSearchResults;
+        const tab = await getCurrentTab();
+        if (!tab?.id) {
+            return;
+        }
+
+        const storageKey = getPendingStorageKey('pendingSearchResults', tab.id);
+        const result = await browser.storage.local.get(storageKey);
+        const pendingResults = result[storageKey];
 
         if (pendingResults && pendingResults.results && pendingResults.results.length > 0) {
             console.log('发现待显示的搜索结果:', pendingResults.results.length);
@@ -1070,7 +1087,12 @@ async function checkPendingSearchResults() {
             showStatus(`找到 ${pendingResults.results.length} 个匹配的B站视频，请选择：`, 'info');
 
             // 清理已显示的结果
-            await browser.storage.local.remove('pendingSearchResults');
+            await browser.runtime
+                .sendMessage({
+                    type: 'clearSearchResults',
+                    tabId: tab.id
+                })
+                .catch((error) => console.log('清理待显示搜索结果失败:', error));
         }
     } catch (error) {
         console.error('检查待显示搜索结果失败:', error);
@@ -1080,8 +1102,14 @@ async function checkPendingSearchResults() {
 // 检查待显示的未匹配结果（作为备用方案）
 async function checkPendingNoMatchResults() {
     try {
-        const result = await browser.storage.local.get('pendingNoMatchResults');
-        const pendingNoMatchResults = result.pendingNoMatchResults;
+        const tab = await getCurrentTab();
+        if (!tab?.id) {
+            return;
+        }
+
+        const storageKey = getPendingStorageKey('pendingNoMatchResults', tab.id);
+        const result = await browser.storage.local.get(storageKey);
+        const pendingNoMatchResults = result[storageKey];
 
         if (pendingNoMatchResults) {
             console.log('发现待显示的未匹配结果:', pendingNoMatchResults.channelInfo);
@@ -1093,7 +1121,12 @@ async function checkPendingNoMatchResults() {
             showStatus('未找到匹配的B站视频，请手动输入或查看B站空间', 'info');
 
             // 清理已显示的结果
-            await browser.storage.local.remove('pendingNoMatchResults');
+            await browser.runtime
+                .sendMessage({
+                    type: 'clearSearchResults',
+                    tabId: tab.id
+                })
+                .catch((error) => console.log('清理待显示未匹配结果失败:', error));
         }
     } catch (error) {
         console.error('检查待显示未匹配结果失败:', error);
@@ -1310,7 +1343,10 @@ async function downloadDanmakuFromBV(bvid, youtubeVideoId = null) {
 
             // 清理后台的搜索结果数据
             browser.runtime
-                .sendMessage({ type: 'clearSearchResults' })
+                .sendMessage({
+                    type: 'clearSearchResults',
+                    tabId: tab.id
+                })
                 .catch((error) => console.log('清理搜索结果失败:', error));
 
             // 显示完成状态，然后自动关闭popup
@@ -1333,37 +1369,59 @@ async function downloadDanmakuFromBV(bvid, youtubeVideoId = null) {
 // 立即设置消息监听器，不等待DOM加载
 browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === 'displayMultipleResults') {
-        console.log('收到搜索结果消息:', request.data.results.length);
+        (async () => {
+            const tab = await getCurrentTab();
+            if (request.tabId != null && tab?.id != null && request.tabId !== tab.id) {
+                console.log('忽略其他标签页的搜索结果消息:', request.tabId, tab.id);
+                sendResponse({ success: false, ignored: true });
+                return;
+            }
 
-        // 如果DOM还未加载完成，等待一下
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => {
+            console.log('收到搜索结果消息:', request.data.results.length);
+
+            const renderResults = () => {
                 displaySearchResults(request.data.results, request.data.youtubeVideoId);
                 showStatus(`找到 ${request.data.results.length} 个匹配的B站视频，请选择：`, 'info');
-            });
-        } else {
-            // DOM已就绪，直接显示
-            displaySearchResults(request.data.results, request.data.youtubeVideoId);
-            showStatus(`找到 ${request.data.results.length} 个匹配的B站视频，请选择：`, 'info');
-        }
+            };
 
-        sendResponse({ success: true });
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', renderResults, { once: true });
+            } else {
+                renderResults();
+            }
+
+            sendResponse({ success: true });
+        })().catch((error) => {
+            console.error('处理搜索结果消息失败:', error);
+            sendResponse({ success: false, error: error.message });
+        });
     } else if (request.type === 'displayNoMatchResults') {
-        console.log('收到未匹配结果消息:', request.data);
+        (async () => {
+            const tab = await getCurrentTab();
+            if (request.tabId != null && tab?.id != null && request.tabId !== tab.id) {
+                console.log('忽略其他标签页的未匹配消息:', request.tabId, tab.id);
+                sendResponse({ success: false, ignored: true });
+                return;
+            }
 
-        // 如果DOM还未加载完成，等待一下
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => {
+            console.log('收到未匹配结果消息:', request.data);
+
+            const renderNoMatch = () => {
                 updateManualInputUI(false, '', request.data);
                 showStatus('未找到匹配的B站视频，请手动输入或查看B站空间', 'info');
-            });
-        } else {
-            // DOM已就绪，直接显示
-            updateManualInputUI(false, '', request.data);
-            showStatus('未找到匹配的B站视频，请手动输入或查看B站空间', 'info');
-        }
+            };
 
-        sendResponse({ success: true });
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', renderNoMatch, { once: true });
+            } else {
+                renderNoMatch();
+            }
+
+            sendResponse({ success: true });
+        })().catch((error) => {
+            console.error('处理未匹配结果消息失败:', error);
+            sendResponse({ success: false, error: error.message });
+        });
     }
 
     return true; // 保持消息通道开启
@@ -1371,18 +1429,23 @@ browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 // 消息监听器设置完成后，立即通知background popup已准备好
 console.log('消息监听器已设置，通知background popup准备完成');
-browser.runtime
-    .sendMessage({ type: 'popupReady' })
-    .then((response) => {
+(async () => {
+    try {
+        const tab = await getCurrentTab();
+        const response = await browser.runtime.sendMessage({
+            type: 'popupReady',
+            tabId: tab?.id ?? null
+        });
+
         if (response && response.success) {
             console.log('成功通知background popup已准备完成');
         } else {
             console.log('background暂无待显示的搜索结果');
         }
-    })
-    .catch((error) => {
+    } catch (error) {
         console.log('通知background失败:', error);
-    });
+    }
+})();
 
 // 检查页面类型并切换界面
 async function checkPageTypeAndToggleUI() {

--- a/entrypoints/popup/popup.js
+++ b/entrypoints/popup/popup.js
@@ -365,7 +365,33 @@ async function checkCurrentPageDanmaku() {
         // 当检测到有弹幕数据时，清理可能残留的未匹配状态数据
         await browser.storage.local.remove(['pendingNoMatchResults', 'pendingSearchResults']);
     } else {
-        updateManualInputUI(false);
+        const noMatchData = await getNoMatchDataForCurrentPage();
+        updateManualInputUI(false, '', noMatchData);
+    }
+}
+
+async function getNoMatchDataForCurrentPage() {
+    try {
+        const pageInfo = await getPageInfo();
+        if (!pageInfo || !pageInfo.channel?.success || !pageInfo.channel.channelId) {
+            return null;
+        }
+
+        const association = await channelAssociation.getChannelAssociation(
+            pageInfo.channel.channelId
+        );
+        if (!association) {
+            return null;
+        }
+
+        return {
+            youtubeVideoId: pageInfo.videoId,
+            channelInfo: pageInfo.channel,
+            videoTitle: pageInfo.videoTitle
+        };
+    } catch (error) {
+        console.error('获取未匹配状态数据失败:', error);
+        return null;
     }
 }
 
@@ -950,7 +976,11 @@ async function autoSearchDanmaku(silent = false) {
         });
 
         if (searchResponse.success) {
-            displaySearchResults(searchResponse.results, pageInfo.videoId);
+            displaySearchResults(searchResponse.results, pageInfo.videoId, {
+                youtubeVideoId: pageInfo.videoId,
+                channelInfo: pageInfo.channel,
+                videoTitle: pageInfo.videoTitle
+            });
             return true;
         } else {
             if (!silent) showStatus(searchResponse.error || '搜索失败', 'error');
@@ -964,7 +994,7 @@ async function autoSearchDanmaku(silent = false) {
 }
 
 // 显示搜索结果
-function displaySearchResults(results, youtubeVideoId) {
+function displaySearchResults(results, youtubeVideoId, noMatchData = null) {
     const searchResults = document.getElementById('search-results');
     const searchStatus = document.getElementById('search-status');
     const searchList = document.getElementById('search-list');
@@ -974,6 +1004,7 @@ function displaySearchResults(results, youtubeVideoId) {
     if (results.length === 0) {
         searchStatus.textContent = '未找到匹配的视频';
         searchList.innerHTML = '';
+        updateManualInputUI(false, '', noMatchData);
     } else if (results.length === 1) {
         searchStatus.textContent = '找到1个匹配视频，正在自动下载弹幕...';
         searchList.innerHTML = '';
@@ -1243,7 +1274,14 @@ async function downloadDanmakuFromBV(bvid, youtubeVideoId = null) {
             console.log('获取YouTube视频长度失败:', error);
         }
 
-        console.log('下载弹幕 - BVID:', bvid, 'YouTube视频ID:', youtubeVideoId, 'YouTube视频长度:', youtubeVideoDuration);
+        console.log(
+            '下载弹幕 - BVID:',
+            bvid,
+            'YouTube视频ID:',
+            youtubeVideoId,
+            'YouTube视频长度:',
+            youtubeVideoDuration
+        );
 
         showStatus('正在下载弹幕...', 'loading');
 
@@ -1393,10 +1431,10 @@ function bindQuarkUIEvents() {
         downloadBtn.setAttribute('data-bound', 'true');
         downloadBtn.addEventListener('click', downloadQuarkDanmaku);
     }
-    
+
     // 设置变更事件
     const settingIds = ['quark-enable-danmaku', 'quark-opacity', 'quark-font-size', 'quark-speed'];
-    settingIds.forEach(id => {
+    settingIds.forEach((id) => {
         const el = document.getElementById(id);
         if (el && !el.hasAttribute('data-bound')) {
             el.setAttribute('data-bound', 'true');
@@ -1406,11 +1444,11 @@ function bindQuarkUIEvents() {
             });
         }
     });
-    
+
     // 时间偏移滑块和输入框同步
     const timeOffsetSlider = document.getElementById('quark-time-offset');
     const timeOffsetInput = document.getElementById('quark-time-offset-input');
-    
+
     if (timeOffsetSlider && !timeOffsetSlider.hasAttribute('data-bound')) {
         timeOffsetSlider.setAttribute('data-bound', 'true');
         timeOffsetSlider.addEventListener('input', () => {
@@ -1420,7 +1458,7 @@ function bindQuarkUIEvents() {
             saveQuarkSettings();
         });
     }
-    
+
     if (timeOffsetInput && !timeOffsetInput.hasAttribute('data-bound')) {
         timeOffsetInput.setAttribute('data-bound', 'true');
         timeOffsetInput.addEventListener('input', () => {
@@ -1432,7 +1470,7 @@ function bindQuarkUIEvents() {
             saveQuarkSettings();
         });
     }
-    
+
     // 加载设置
     loadQuarkSettings();
 }
@@ -1442,7 +1480,7 @@ function updateQuarkSliderValues() {
     const opacityEl = document.getElementById('quark-opacity');
     const fontSizeEl = document.getElementById('quark-font-size');
     const speedEl = document.getElementById('quark-speed');
-    
+
     if (opacityEl) {
         document.getElementById('quark-opacity-value').textContent = opacityEl.value + '%';
     }
@@ -1459,9 +1497,10 @@ async function saveQuarkSettings() {
     // 优先使用输入框的值
     const timeOffsetInput = document.getElementById('quark-time-offset-input');
     const timeOffsetSlider = document.getElementById('quark-time-offset');
-    const timeOffset = timeOffsetInput && timeOffsetInput.value !== ''
-        ? parseFloat(timeOffsetInput.value) || 0
-        : parseFloat(timeOffsetSlider?.value) || 0;
+    const timeOffset =
+        timeOffsetInput && timeOffsetInput.value !== ''
+            ? parseFloat(timeOffsetInput.value) || 0
+            : parseFloat(timeOffsetSlider?.value) || 0;
 
     const settings = {
         enabled: document.getElementById('quark-enable-danmaku')?.checked ?? true,
@@ -1518,7 +1557,7 @@ async function loadQuarkSettings() {
 function showQuarkStatus(message, type = 'loading') {
     const statusBar = document.getElementById('quark-status-bar');
     if (!statusBar) return;
-    
+
     statusBar.textContent = message;
     statusBar.className = `status-bar show ${type}`;
 
@@ -1533,7 +1572,7 @@ function showQuarkStatus(message, type = 'loading') {
 async function downloadQuarkDanmaku() {
     const urlInput = document.getElementById('quark-bilibili-url');
     const url = urlInput?.value?.trim();
-    
+
     if (!url) {
         showQuarkStatus('请输入B站视频链接', 'error');
         return;
@@ -1554,7 +1593,7 @@ async function downloadQuarkDanmaku() {
     // 从 URL 获取 Quark 视频 ID
     const hashMatch = tab.url.match(/#\/video\/([a-zA-Z0-9]+)/);
     const quarkVideoId = hashMatch ? hashMatch[1] : null;
-    
+
     if (!quarkVideoId) {
         showQuarkStatus('请在视频播放页面使用', 'error');
         return;
@@ -1586,7 +1625,7 @@ async function downloadQuarkDanmaku() {
 
         if (response.success) {
             showQuarkStatus(`成功下载 ${response.count} 条弹幕`, 'success');
-            
+
             // 更新弹幕信息显示
             const danmakuInfo = document.getElementById('quark-danmaku-info');
             if (danmakuInfo) {
@@ -1693,32 +1732,32 @@ async function checkQuarkDanmaku() {
 
     const hashMatch = tab.url.match(/#\/video\/([a-zA-Z0-9]+)/);
     const quarkVideoId = hashMatch ? hashMatch[1] : null;
-    
+
     if (!quarkVideoId) return;
 
     const storageKey = `quark_${quarkVideoId}`;
     const result = await browser.storage.local.get(storageKey);
-    
+
     if (result[storageKey] && result[storageKey].danmakus) {
         const data = result[storageKey];
-        
+
         // 显示已加载的弹幕信息
         const danmakuInfo = document.getElementById('quark-danmaku-info');
         if (danmakuInfo) {
             danmakuInfo.textContent = `已加载 ${data.danmakus.length} 条弹幕`;
             danmakuInfo.classList.add('show');
         }
-        
+
         // 显示弹幕列表
         displayQuarkDanmakuList(data.danmakus);
-        
+
         // 填充 URL
         const urlInput = document.getElementById('quark-bilibili-url');
         if (urlInput && data.bilibili_url) {
             urlInput.value = data.bilibili_url;
         }
     }
-    
+
     // 获取并显示视频标题
     try {
         const response = await browser.tabs.sendMessage(tab.id, { type: 'getPageInfo' });
@@ -1810,7 +1849,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await checkQuarkDanmaku();
         return;
     }
-    
+
     // 如果不是YouTube页面，不需要执行后续的初始化逻辑
     if (pageType !== 'youtube') {
         return;


### PR DESCRIPTION
## 概述

修复 YouTube 弹幕初始化时序问题和 Popup 页面数据隔离问题。

Fixes #5, mitigates #32

## 主要改动

### 1. 修复 YouTube 弹幕初始化时序 (`content/index.js`)
- 引入 `activeInitToken` 机制，避免在 YouTube SPA 导航时出现过时的弹幕初始化竞争
- 增加 `pendingInitTimeout` 追踪，确保页面切换时能正确清理待执行的初始化
- 重构频道信息获取逻辑：提取 `findChannelLinkCandidate()`、`getChannelAvatar()`、`extractChannelIdFromHref()` 等辅助函数，通过可见性检测 (`isVisibleElement`) 和作用域搜索精确匹配当前视频的频道信息，避免获取到过时或不相关的频道数据

### 2. Popup 页面信息按标签页隔离 (`background/index.js`, `popup/popup.js`)
- 将全局的 `pendingSearchResults` / `pendingNoMatchResults` 改为按 `tabId` 隔离存储
- 新增 `getPendingPopupData`、`setPendingPopupData`、`clearPendingPopupData` 等管理函数，同时维护内存缓存和 `storage.local` 持久化
- Popup 端 `checkPendingSearchResults` 改为仅读取当前标签页对应的数据，防止跨标签页数据串扰

### 3. 无匹配时显示 Bilibili 空间链接 (`popup/popup.js`)
- 搜索结果为空时，通过 `getNoMatchDataForCurrentPage()` 获取当前频道关联信息，在 Popup 中展示对应的 Bilibili 空间入口